### PR TITLE
Fix for the wrapping issue for the last day

### DIFF
--- a/src/styles.module.css
+++ b/src/styles.module.css
@@ -1,6 +1,6 @@
 .time_table_wrapper {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   height: 100%;
   margin: 0;
   font-family: 'Open Sans', sans-serif;
@@ -10,7 +10,7 @@
 
 .day {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   flex-direction: column;
   position: relative;
   background-color: #fff;


### PR DESCRIPTION
Hello,

I wanted to start off by thanking you for making this React timetable, it really helped our project.

There was one bug that we faced when the calendar was not 100% of the page and it has to do with the dynamic calculations that made Friday (or Sunday) typically on a very wide screen to wrap and then overflow and become hidden. 

After a lot of debugging the fix was the force the `.time_table_wrapper` and `.day` to be `flex-wrap: nowrap`. Although this is a bandage solution - it fixed the issue for us. I thought I would share it. 

Before:
![Screenshot 2023-12-09 at 3 27 46 AM](https://github.com/nikolasp/react-timetable-events/assets/65968691/5ba21713-2a16-436c-9247-ff510e5f975e)
After:
![Screenshot 2023-12-09 at 3 42 25 AM](https://github.com/nikolasp/react-timetable-events/assets/65968691/3d636ff9-f3dc-452e-9ce3-6edbfbe4a4c5)

